### PR TITLE
feat(home): add minimal Home screen with header and quick actions placeholders

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,13 @@
-import React from "react";
+
 import "./styles/globals.css";
+import Header from "./components/Header";
+import Home from "./pages/Home";
 
 export default function App() {
     return (
-        <div className="container">
-            <h1>Homiq</h1>
-            <p>זהו שלד בסיסי. נוסיף פיצ'רים בהמשך, כל אחד ב־branch נפרד ב־Git.</p>
-            <div className="card">
-                <p>React + Vite + TypeScript + CSS נפרד</p>
-            </div>
-        </div>
+        <>
+            <Header />
+            <Home />
+        </>
     );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,14 @@
+
+export default function Header() {
+    return (
+        <header style={{ padding: "1rem 0", borderBottom: "1px solid #1f2937" }}>
+            <div className="container" style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <strong>Homiq</strong>
+                <nav style={{ display: "flex", gap: "1rem" }}>
+                    <a href="#" aria-disabled="true" style={{ opacity: 0.6, pointerEvents: "none" }}>Devices</a>
+                    <a href="#" aria-disabled="true" style={{ opacity: 0.6, pointerEvents: "none" }}>Settings</a>
+                </nav>
+            </div>
+        </header>
+    );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,22 @@
+
+export default function Home() {
+    return (
+        <div className="container">
+            <h1>🏠 Homiq</h1>
+            <p>Welcome Homiq</p>
+
+            <div className="card" style={{ marginTop: "1rem" }}>
+                <h3 style={{ marginTop: 0 }}>Quick Actions</h3>
+                <div style={{ display: "flex", gap: ".5rem", flexWrap: "wrap" }}>
+                    <button className="btn" disabled>☀️ Good Morning (coming soon)</button>
+                    <button className="btn" disabled>🎬 Movie Night (coming soon)</button>
+                </div>
+            </div>
+
+            <div className="card" style={{ marginTop: "1rem" }}>
+                <h3 style={{ marginTop: 0 }}>Status</h3>
+                <p>אין עדיין נתוני מכשירים — נתחיל להוסיף בהמשך.</p>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION

This PR introduces the initial Home screen for the Homiq smart home application.
It includes:
- A reusable Header component with app name and placeholder navigation links (Devices, Settings).
- A Home page displaying a welcome message.
- A Quick Actions card with placeholder buttons for upcoming Scenes (Good Morning, Movie Night).
- A Status card placeholder to display device states in the future.

**User Story Reference: US-006: Minimal Home Screen**
- As a user, I want to see a basic home screen with the app name, quick actions area, and a placeholder status section.

**Acceptance Criteria:**
- Header with app name is displayed at the top.
- Quick Actions card shows 2 disabled buttons for upcoming Scenes.
- Status card is present with placeholder text.
- Page loads without errors.